### PR TITLE
Add sample Elixir OpenAI client

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,29 @@
+# Elxrgpt
+
+Example Elixir project showing how to call the OpenAI ChatGPT API.
+
+## Setup
+
+1. Install Elixir and Mix.
+2. Fetch dependencies:
+
+```bash
+mix deps.get
+```
+
+3. Set your OpenAI API key:
+
+```bash
+export OPENAI_API_KEY=your_key_here
+```
+
+## Usage
+
+Start an `iex` session and call the helper:
+
+```elixir
+iex -S mix
+Elxrgpt.ask("Hello!")
+```
+
+The module will return the assistant's reply.

--- a/lib/elxrgpt.ex
+++ b/lib/elxrgpt.ex
@@ -1,0 +1,18 @@
+defmodule Elxrgpt do
+  @moduledoc """
+  Entry point for interacting with the OpenAI client.
+  """
+
+  alias Elxrgpt.OpenAIClient
+
+  @doc """
+  Sends a single message and returns the assistant's reply.
+  """
+  def ask(prompt) when is_binary(prompt) do
+    messages = [%{"role" => "user", "content" => prompt}]
+
+    with {:ok, %{"choices" => [%{"message" => msg}|_]} } <- OpenAIClient.chat_completion(messages) do
+      {:ok, msg["content"]}
+    end
+  end
+end

--- a/lib/elxrgpt/openai_client.ex
+++ b/lib/elxrgpt/openai_client.ex
@@ -1,0 +1,30 @@
+defmodule Elxrgpt.OpenAIClient do
+  @moduledoc """
+  Simple client for OpenAI's Chat Completion API.
+  """
+
+  @endpoint "https://api.openai.com/v1/chat/completions"
+
+  def chat_completion(messages, opts \\ []) when is_list(messages) do
+    body = %{
+      "model" => Keyword.get(opts, :model, "gpt-3.5-turbo"),
+      "messages" => messages
+    }
+
+    headers = [
+      {"Content-Type", "application/json"},
+      {"Authorization", "Bearer #{api_key()}"}
+    ]
+
+    with {:ok, response} <- HTTPoison.post(@endpoint, Jason.encode!(body), headers, recv_timeout: 30_000),
+         {:ok, decoded} <- Jason.decode(response.body) do
+      {:ok, decoded}
+    else
+      error -> error
+    end
+  end
+
+  defp api_key do
+    System.get_env("OPENAI_API_KEY") || raise "OPENAI_API_KEY env var not set"
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -1,0 +1,24 @@
+defmodule Elxrgpt.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :elxrgpt,
+      version: "0.1.0",
+      elixir: "~> 1.14",
+      start_permanent: Mix.env() == :prod,
+      deps: deps()
+    ]
+  end
+
+  def application do
+    [extra_applications: [:logger, :httpoison]]
+  end
+
+  defp deps do
+    [
+      {:httpoison, "~> 1.8"},
+      {:jason, "~> 1.4"}
+    ]
+  end
+end


### PR DESCRIPTION
## Summary
- show how to call ChatGPT from Elixir
- add an OpenAI client and helper

## Testing
- `mix test` *(fails: `mix` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851772649788331940a42991b03e437